### PR TITLE
Use pbr to handle setuptools config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,40 @@
+[metadata]
+name = rdial
+author = James Rowe
+author-email = jnrowe@gmail.com
+home-page  = https://github.com/JNRowe/rdial/
+summary = Simple time tracking for simple people
+description-file = README.rst
+license = GPL-3
+classifier =
+    Development Status :: 5 - Production/Stable
+    Environment :: Console
+    Intended Audience :: Developers
+    Intended Audience :: End Users/Desktop
+    Intended Audience :: Other Audience
+    Intended Audience :: System Administrators
+    License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
+    Natural Language :: English
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.6
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.1
+    Programming Language :: Python :: 3.2
+    Programming Language :: Python :: 3.3
+    Topic :: Office/Business
+    Topic :: Office/Business :: News/Diary
+    Topic :: Office/Business :: Scheduling
+    Topic :: Other/Nonlisted Topic
+    Topic :: Text Processing :: Filters
+    Topic :: Utilities
+keywords =
+    timetracking
+    task
+    report
+
 [aliases]
 build_dist = sdist --formats=gztar,bztar,zip
 
@@ -22,3 +59,7 @@ ignore-obsolete = true
 
 [wheel]
 universal = 1
+
+[entry_points]
+console_scripts =
+    rdial = rdial.cmdline:main

--- a/setup.py
+++ b/setup.py
@@ -19,49 +19,7 @@
 
 from setuptools import setup
 
-from rdial import _version
-
-install_requires = map(str.strip, open('extra/requirements.txt').readlines())
-
 setup(
-    name='rdial',
-    version=_version.dotted,
-    description='Simple time tracking for simple people',
-    long_description=open('README.rst').read(),
-    author='James Rowe',
-    author_email='jnrowe@gmail.com',
-    url='https://github.com/JNRowe/rdial',
-    license='GPL-3',
-    keywords='timetracking task report',
-    packages=['rdial', ],
-    include_package_data=True,
-    package_data={'': ['config', 'rdial/locale/*/LC_MESSAGES/*.mo']},
-    entry_points={'console_scripts': ['rdial = rdial.cmdline:main', ]},
-    install_requires=install_requires,
-    zip_safe=False,
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Console',
-        'Intended Audience :: Developers',
-        'Intended Audience :: End Users/Desktop',
-        'Intended Audience :: Other Audience',
-        'Intended Audience :: System Administrators',
-        'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.1',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Topic :: Office/Business',
-        'Topic :: Office/Business :: News/Diary',
-        'Topic :: Office/Business :: Scheduling',
-        'Topic :: Other/Nonlisted Topic',
-        'Topic :: Text Processing :: Filters',
-        'Topic :: Utilities',
-    ],
+    setup_requires=['pbr', ],
+    pbr=True,
 )


### PR DESCRIPTION
This _feels_ cleaner initially, but the bootstrap situation may make deployment annoying.

Really like the version identifier, need to use that data at runtime before this can be merged.  Not sure how to handle the "run from dir" case at all yet.
