### PR TITLE
Cache read CSV files

### DIFF
--- a/doc/api/utils.rst
+++ b/doc/api/utils.rst
@@ -15,6 +15,8 @@ Convenience functions
 .. autofunction:: write_current
 .. autofunction:: remove_current
 
+.. autofunction:: newer
+
 Time handling
 '''''''''''''
 
@@ -25,6 +27,7 @@ Time handling
 XDG Base Directory support
 ''''''''''''''''''''''''''
 
+.. autofunction:: xdg_cache_location
 .. autofunction:: xdg_data_location
 
 Text formatting

--- a/rdial/utils.py
+++ b/rdial/utils.py
@@ -223,6 +223,27 @@ def remove_current(f):
     return wrapper
 
 
+def newer(file, reference):
+    """Check whether given file is newer than reference file.
+
+    :param str file: File to check
+    :param str reference: file to test against
+    :rtype: :obj:`bool`
+    :return: True if ``reference`` is newer than ``reference``
+    """
+    return os.stat(file).st_mtime > os.stat(reference).st_mtime
+
+
+def xdg_cache_location():
+    """Return a cache location honouring $XDG_CACHE_HOME.
+
+    :rtype: :obj:`str`
+    """
+    user_dir = os.getenv('XDG_CACHE_HOME',
+                         os.path.join(os.getenv('HOME', '/'), '.cache'))
+    return os.path.join(user_dir, 'rdial')
+
+
 def xdg_config_location():
     """Return a config location honouring $XDG_CONFIG_HOME.
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -64,7 +64,8 @@ def test_event_creation(task, start, delta, message):
     ('test_not_running', 3),
 )
 def test_read_datebase(database, events):
-    expect(len(Events.read('tests/data/' + database))) == events
+    evs = Events.read('tests/data/' + database, write_cache=False)
+    expect(len(evs)) == events
 
 
 @params(
@@ -77,7 +78,7 @@ def test_read_datebase(database, events):
 def test_check_events(n, task, start, delta):
     # FIXME: Clean-ish way to perform check, with the caveat that it parses the
     # database on each entry.  Need a better solution.
-    events = Events.read('tests/data/test')
+    events = Events.read('tests/data/test', write_cache=False)
     expect(events[n].task) == task
     expect(events[n].start) == start
     expect(events[n].delta) == delta
@@ -86,7 +87,7 @@ def test_check_events(n, task, start, delta):
 def test_write_database():
     runner = CliRunner()
     in_dir = abspath('tests/data/test')
-    events = Events.read(in_dir)
+    events = Events.read(in_dir, write_cache=False)
     events._dirty = events.tasks()
     with runner.isolated_filesystem() as tempdir:
         events.write(tempdir)
@@ -98,9 +99,9 @@ def test_write_database():
 
 
 def test_store_messages_with_events():
-    events = Events.read('tests/data/test')
+    events = Events.read('tests/data/test', write_cache=False)
     expect(events.last().message) == 'finished'
 
 
 def test_non_existing_database():
-    expect(Events()) == Events.read('I_NEVER_EXIST')
+    expect(Events()) == Events.read('I_NEVER_EXIST', write_cache=False)

--- a/tests/test_event_filter.py
+++ b/tests/test_event_filter.py
@@ -24,7 +24,7 @@ from rdial.events import Events
 
 
 def test_fetch_events_for_task():
-    events = Events.read('tests/data/test')
+    events = Events.read('tests/data/test', write_cache=False)
     expect(len(events.for_task(task='task2'))) == 1
 
 
@@ -35,10 +35,10 @@ def test_fetch_events_for_task():
     ({'year': 2011, 'month': 3, 'day': 31}, 0),
 )
 def test_fetch_events_for_date(date, expected):
-    events = Events.read('tests/data/date_filtering')
+    events = Events.read('tests/data/date_filtering', write_cache=False)
     expect(len(events.for_date(**date))) == expected
 
 
 def test_fetch_events_for_week():
-    events = Events.read('tests/data/date_filtering')
+    events = Events.read('tests/data/date_filtering', write_cache=False)
     expect(len(events.for_week(year=2011, week=9))) == 1

--- a/tests/test_event_query.py
+++ b/tests/test_event_query.py
@@ -25,20 +25,20 @@ from rdial.events import Events
 
 
 def test_list_tasks():
-    events = Events.read('tests/data/test')
+    events = Events.read('tests/data/test', write_cache=False)
     expect(events.tasks()) == ['task', 'task2']
 
 
 def test_current_running_event():
-    events = Events.read('tests/data/test')
+    events = Events.read('tests/data/test', write_cache=False)
     expect(events.running()) == 'task'
 
 
 def test_no_currently_running_event():
-    events = Events.read('tests/data/test_not_running')
+    events = Events.read('tests/data/test_not_running', write_cache=False)
     expect(events.running()) is False
 
 
 def test_sum_durations_in_database():
-    events = Events.read('tests/data/test_not_running')
+    events = Events.read('tests/data/test_not_running', write_cache=False)
     expect(events.sum()) == timedelta(hours=2, minutes=15)

--- a/tests/test_event_triggers.py
+++ b/tests/test_event_triggers.py
@@ -25,13 +25,13 @@ from rdial.events import (Events, TaskNotExistError, TaskNotRunningError,
 
 
 def test_start_event():
-    events = Events.read('tests/data/test_not_running')
+    events = Events.read('tests/data/test_not_running', write_cache=False)
     events.start(task='task2')
     expect(events.running()) == 'task2'
 
 
 def test_fail_start_when_task_typo():
-    events = Events.read('tests/data/test_not_running')
+    events = Events.read('tests/data/test_not_running', write_cache=False)
     with expect.raises(TaskNotExistError,
                        "Task non_existant does not exist!  Use `--new' to "
                        'create it'):
@@ -39,25 +39,25 @@ def test_fail_start_when_task_typo():
 
 
 def test_fail_start_when_running():
-    events = Events.read('tests/data/test')
+    events = Events.read('tests/data/test', write_cache=False)
     with expect.raises(TaskRunningError, 'Running task task!'):
         events.start(task='task2')
 
 
 def test_stop_event():
-    events = Events.read('tests/data/test')
+    events = Events.read('tests/data/test', write_cache=False)
     events.stop()
     expect(events.running()) is False
 
 
 def test_stop_event_with_message():
-    events = Events.read('tests/data/test')
+    events = Events.read('tests/data/test', write_cache=False)
     events.stop(message='test')
     last = events.last()
     expect(last.message) == 'test'
 
 
 def test_fail_stop_when_not_running():
-    events = Events.read('tests/data/test_not_running')
+    events = Events.read('tests/data/test_not_running', write_cache=False)
     with expect.raises(TaskNotRunningError, 'No task running!'):
         events.stop()


### PR DESCRIPTION
This reduces _my_ personal runs by two thirds, and is reasonably robust.  It's basically option 5 from #17.

Admittedly `pickle` wasn't my first choice for obvious reasons, but it is only used _after_ validation on reads and it is considerably faster than manually marshalling the `datetime` objects with JSON.

Refs #17.
