### PR TITLE
Switch to tabulate for report formatting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Requirements
 * blessings_
 * click_
 * configobj_
-* prettytable_
+* tabulate_
 
 It should work with any version of Python_ 2.6 or newer.  If ``rdial`` doesn't
 work with the version of Python you have installed, file an issue_ and I'll
@@ -123,7 +123,7 @@ reproduce the problem, or even better a patch!
 .. _blessings: https://crate.io/packages/blessings/
 .. _click: https://crate.io/packages/click/
 .. _configobj: https://crate.io/packages/configobj/
-.. _prettytable: http://code.google.com/p/prettytable/
+.. _tabulate: https://crate.io/packages/tabulate/
 .. _Python: http://www.python.org/
 .. _issue: https://github.com/JNRowe/rdial/issues
 .. _nose2: https://crate.io/packages/nose2/

--- a/doc/rdial.1.rst
+++ b/doc/rdial.1.rst
@@ -165,8 +165,8 @@ Report time tracking data
 -r, --reverse
     Reverse sort order.
 
---html
-    Produce HTML output.
+--style
+    Table output style {grid,latex,mediawiki,orgtbl,pipe,plain,rst,simple,tsv}.
 
 --human
     Produce human-readable output.

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -203,7 +203,7 @@ See :ref:`run wrappers configuration <run-wrappers-label>`.
 
 ::
 
-    rdial report [--help] [-d <duration>] [-s <order] [-r] [--html] [--human] <task>
+    rdial report [--help] [-d <duration>] [-s <order] [-r] [--style] [--human] <task>
 
 .. option:: -d <duration>, --duration=<duration>
 
@@ -217,9 +217,9 @@ See :ref:`run wrappers configuration <run-wrappers-label>`.
 
    Reverse sort order.
 
-.. option:: --html
+.. option:: --style
 
-   Produce HTML output.
+   Table output style {grid,latex,mediawiki,orgtbl,pipe,plain,rst,simple,tsv}
 
 .. option:: --human
 

--- a/extra/_rdial
+++ b/extra/_rdial
@@ -21,6 +21,17 @@
 # customise it!  If you make improvements, open a pull request against
 # `JNRowe/rdial' with your super changes attached.
 
+(( $+functions[__list_styles] )) ||
+__list_styles() {
+    local tmp
+    tmp=($(python -c 'import tabulate; print(" ".join(tabulate._table_formats.keys()))' 2>/dev/null))
+    if [ -z "${tmp}" ]; then
+        _message "No styles found!"
+    else
+        compadd ${tmp[@]}
+    fi
+}
+
 (( $+functions[__list_tasks] )) ||
 __list_tasks() {
     local tmp
@@ -100,8 +111,8 @@ case "$words[1]" in
     _arguments '--help[show help message and exit]' \
         '--duration[filter events for specified time period]:select time period:(day week month year all)' \
         '--sort[field to sort by]:select sort field:(task time)' \
+        '--style[table output style]:__list_styles' \
         '--reverse[reverse sort order]' \
-        '--html[produce HTML output]' \
         '--human[produce human-readable output]' \
         '--from-dir[use directory name as task]' \
         ':select task:__list_tasks'

--- a/extra/requirements.txt
+++ b/extra/requirements.txt
@@ -1,4 +1,4 @@
 arrow>=0.4.2
 click
 configobj>=5.0.0
-prettytable
+tabulate

--- a/rdial/cmdline.py
+++ b/rdial/cmdline.py
@@ -19,13 +19,14 @@
 
 # pylint: disable-msg=C0121
 
+import operator
 import os
 import shlex
 import subprocess
 
 import arrow
 import click
-import prettytable
+import tabulate
 
 from .events import (Events, TaskNotRunningError, TaskRunningError)
 from .i18n import (_, N_)
@@ -363,10 +364,7 @@ def wrapper(ctx, globs, time, message, file, wrapper):
               help=_('Use directory name as task name.'))
 @click.argument('task', default='default', envvar='RDIAL_TASK',
                 required=False, type=TaskNameParamType())
-@click.option('--html', 'output', flag_value='html',
-              help=_('Produce HTML output.'))
-@click.option('--human', 'output', flag_value='human',
-              help=_('Produce human-readable output.'))
+@click.option('--human', help=_('Produce human-readable output.'))
 @click.option('-d', '--duration', default='all',
               type=click.Choice(['day', 'week', 'month', 'year', 'all']),
               help=_('Filter events for specified time period.'))
@@ -374,22 +372,26 @@ def wrapper(ctx, globs, time, message, file, wrapper):
               type=click.Choice(['task', 'time']), help=_('Field to sort by.'))
 @click.option('-r', '--reverse/--no-reverse', default=False,
               envvar='RDIAL_REVERSE', help=_('Reverse sort order.'))
+@click.option('--style', default='simple', envvar='RDIAL_TABLE_STYLE',
+              type=click.Choice(tabulate._table_formats.keys()),
+              help=_('Table output style.'))
 @click.pass_obj
-def report(globs, task, output, duration, sort, reverse):
+def report(globs, task, human, duration, sort, reverse, style):
     """Report time tracking data.
 
     :param dict globs: Global options object
     :param str task: Task name to operate on
-    :param str output: Type of output to produce
+    :param bool human: Display short overview of data
     :param str duration: Time window to filter on
     :param str sort: Key to sort events on
     :param bool reverse: Reverse sort order
+    :param str style: Table formatting style
     """
     if task == 'default':
         # Lazy way to remove duplicate argument definitions
         task = None
     events = filter_events(globs.directory, task, duration)
-    if output == 'human':
+    if human:
         click.echo(N_('%d event in query', '%d events in query', len(events))
                    % len(events))
         click.echo(_('Duration of events %s') % events.sum())
@@ -398,20 +400,13 @@ def report(globs, task, output, duration, sort, reverse):
         dates = set(e.start.date() for e in events)
         click.echo(_('Events exist on %d dates') % len(dates))
     else:
-        table = prettytable.PrettyTable(['task', 'time'])
-        if output == 'html':
-            formatter = table.get_html_string
-        else:
-            formatter = table.get_string
-        try:
-            table.align['task'] = 'l'
-        except AttributeError:  # prettytable 0.5 compatibility
-            table.set_field_align('task', 'l')
-        for task in events.tasks():
-            table.add_row([task, events.for_task(task).sum()])
-
-        click.echo_via_pager(formatter(sortby=sort, reversesort=reverse))
-    if events.running() and not output == 'html':
+        data = sorted(([t, str(events.for_task(t).sum())]
+                       for t in events.tasks()),
+                      key=operator.itemgetter(['task', 'time'].index(sort)),
+                      reverse=reverse)
+        click.echo_via_pager(tabulate.tabulate(data, ['task', 'time'],
+                                               tablefmt=style))
+    if events.running():
         current = events.last()
         click.echo(_("Task `%s' started %s")
                    % (current.task, current.start.humanize()))


### PR DESCRIPTION
[tabulate](https://pypi.python.org/pypi/tabulate) supports a variety of interesting output formats, and this makes it easy to embed reports in to other documents.  EoM timesheet, I'm looking at you!

Unsure on which report format should be the default in `rdial`, but it will probably fall on reST before this is merged.
