### PR TITLE
Move setup() metadata to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,40 @@ domain = rdial
 input-file = rdial/locale/rdial.pot
 output-dir = rdial/locale
 
+[metadata]
+name = rdial
+author = James Rowe
+author_email = jnrowe@gmail.com
+description = Simple time tracking for simple people
+keywords = timetracking task report
+packages = rdial
+include_package_data = True
+package_data = {'': ['config', 'rdial/locale/*/LC_MESSAGES/*.mo']}
+entry_points = {'console_scripts': ['rdial = rdial.cmdline:main', ]}
+license = GPL-3
+url = https://github.com/JNRowe/rdial
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: Console
+    Intended Audience :: Developers
+    Intended Audience :: End Users/Desktop
+    Intended Audience :: Other Audience
+    Intended Audience :: System Administrators
+    License :: OSI Approved
+    License :: OSI Approved :: GNU General Public License (GPL)
+    License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
+    Natural Language :: English
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Topic :: Office/Business
+    Topic :: Office/Business :: News/Diary
+    Topic :: Office/Business :: Scheduling
+    Topic :: Other/Nonlisted Topic
+    Topic :: Utilities
+
 [pycodestyle]
 select = E, W
 

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,10 @@
 # You should have received a copy of the GNU General Public License along with
 # rdial.  If not, see <http://www.gnu.org/licenses/>.
 
-import imp
 import sys
+
+from configparser import ConfigParser
+from importlib.util import module_from_spec, spec_from_file_location
 
 from setuptools import setup
 from setuptools.command.test import test
@@ -35,11 +37,28 @@ class PytestTest(test):
         exit(main(self.test_args))
 
 
-# Hack to import _version file without importing rdial/__init__.py, its
-# purpose is to allow import without requiring dependencies at this point.
-with open('rdial/_version.py') as ver_file:
-    _version = imp.load_module('_version', ver_file, ver_file.name,
-                               ('.py', ver_file.mode, imp.PY_SOURCE))
+def import_file(package, fname):
+    """Import file directly.
+
+    This is a hack to import files from packages without importing
+    <package>/__init__.py, its purpose is to allow import without requiring
+    all the dependencies at this point.
+
+    Args:
+        package (str): Package to import from
+        fname (str): File to import
+    Returns:
+        types.ModuleType: Imported module
+    """
+    mod_name = fname.rstrip('.py')
+    spec = spec_from_file_location(mod_name, '{}/{}'.format(package, fname))
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_list(s):
+    return s.strip().splitlines()
 
 
 def parse_requires(file):
@@ -62,52 +81,34 @@ def parse_requires(file):
     return deps
 
 
+conf = ConfigParser()
+conf.read('setup.cfg')
+metadata = dict(conf['metadata'])
+
 install_requires = parse_requires('requirements.txt')
 
 tests_require = parse_requires('requirements-test.txt')
 
-with open('README.rst') as f:
-    long_description = f.read()
+metadata = dict(conf['metadata'])
+for k in ['classifiers', 'packages', 'py_modules']:
+    if k in metadata:
+        metadata[k] = make_list(metadata[k])
+
+for k in ['entry_points', 'package_data']:
+    if k in metadata:
+        metadata[k] = eval(metadata[k], {'__builtins__': {}})
+
+with open('README.rst') as readme:
+    metadata['long_description'] = readme.read()
+
+_version = import_file(metadata['name'], '_version.py')
 
 if __name__ == '__main__':
     setup(
-        name='rdial',
         version=_version.dotted,
-        description='Simple time tracking for simple people',
-        long_description=long_description,
-        author='James Rowe',
-        author_email='jnrowe@gmail.com',
-        url='https://github.com/JNRowe/rdial',
-        license='GPL-3',
-        keywords='timetracking task report',
-        packages=['rdial', ],
-        include_package_data=True,
-        package_data={'': ['config', 'rdial/locale/*/LC_MESSAGES/*.mo']},
-        entry_points={'console_scripts': ['rdial = rdial.cmdline:main', ]},
         install_requires=install_requires,
         tests_require=tests_require,
         cmdclass={'test': PytestTest},
         zip_safe=False,
-        classifiers=[
-            'Development Status :: 5 - Production/Stable',
-            'Environment :: Console',
-            'Intended Audience :: Developers',
-            'Intended Audience :: End Users/Desktop',
-            'Intended Audience :: Other Audience',
-            'Intended Audience :: System Administrators',
-            'License :: OSI Approved',
-            'License :: OSI Approved :: GNU General Public License (GPL)',
-            'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
-            'Natural Language :: English',
-            'Operating System :: OS Independent',
-            'Programming Language :: Python',
-            'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.5',
-            'Programming Language :: Python :: 3.6',
-            'Topic :: Office/Business',
-            'Topic :: Office/Business :: News/Diary',
-            'Topic :: Office/Business :: Scheduling',
-            'Topic :: Other/Nonlisted Topic',
-            'Topic :: Utilities',
-        ],
+        **metadata,
     )

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License along with
 # rdial.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
-
 from configparser import ConfigParser
 from importlib.util import module_from_spec, spec_from_file_location
 
@@ -71,12 +69,6 @@ def parse_requires(file):
         elif dep.startswith('-r '):
             deps.extend(parse_requires(dep.split()[1]))
             continue
-        elif ';' in dep:
-            dep, marker = dep.split(';')
-            if not eval(marker.strip(), {
-                    'python_version': '{}.{}'.format(*sys.version_info[:2])
-                }):
-                continue
         deps.append(dep)
     return deps
 

--- a/tests/test_setup_py.py
+++ b/tests/test_setup_py.py
@@ -29,13 +29,3 @@ def test_parse_requires(input, expected):
     requires = setup.parse_requires(
         '../tests/data/requires/{}.txt'.format(input))
     assert requires == expected
-
-
-@mark.parametrize('version, expected', [
-    ((2, 7, 6), ['unicodecsv', ]),
-    ((3, 4, 2), []),
-])
-def test_parse_markers(version, expected, monkeypatch):
-    monkeypatch.setattr(setup.sys, 'version_info', version)
-    requires = setup.parse_requires('../tests/data/requires/markers.txt')
-    assert requires == expected


### PR DESCRIPTION
Mainly a pull request so that I can see a few setup.py uses in the real
world.