### PR TITLE
Use click-log for structured output

### DIFF
--- a/extra/_rdial
+++ b/extra/_rdial
@@ -60,6 +60,7 @@ __list_wrappers() {
 
 _arguments \
     '--version[Show the version and exit.]' \
+    '--verbosity:[Set verbosity level.]:select log level:(CRITICAL ERROR WARNING INFO DEBUG)' \
     "--directory=[Directory to read/write to.]:select directory:_files -/ ${XDG_DATA_HOME:-~/.local/share}" \
     '--backup[Write data file backups.]' \
     '--no-backup[Do not write data file backups.]' \

--- a/extra/requirements.txt
+++ b/extra/requirements.txt
@@ -1,3 +1,4 @@
 click>=7.0
+click-log>=0.3.2
 jnrbase[colour,iso_8601]>=1.0.0
 tabulate

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -566,7 +566,6 @@ def test_main_wrapper_error(monkeypatch, capsys):
     monkeypatch.setattr('sys.exit', exit_mock)
     result = main()
     assert result == 2
-    assert capsys.readouterr()[0] == 'No task running!\n'
 
 
 def test_main_wrapper_informative_return_code(capsys, monkeypatch, tmpdir):


### PR DESCRIPTION
This won’t be merged as-is, but is a playground for testing `click-log`.